### PR TITLE
Move mutex and refcell into implementations

### DIFF
--- a/fluent-bundle/examples/custom_formatter.rs
+++ b/fluent-bundle/examples/custom_formatter.rs
@@ -2,15 +2,13 @@
 // to format selected types of values.
 //
 // This allows users to plug their own number formatter to Fluent.
-use std::sync::Mutex;
-
-use intl_memoizer::IntlLangMemoizer;
 use unic_langid::LanguageIdentifier;
 
-use fluent_bundle::types::{FluentNumber, FluentNumberOptions, FluentValue};
-use fluent_bundle::{FluentArgs, FluentBundle, FluentResource};
+use fluent_bundle::memoizer::MemoizerKind;
+use fluent_bundle::types::{FluentNumber, FluentNumberOptions};
+use fluent_bundle::{FluentArgs, FluentBundle, FluentResource, FluentValue};
 
-fn custom_formatter(num: &FluentValue, _intls: &Mutex<IntlLangMemoizer>) -> Option<String> {
+fn custom_formatter<M: MemoizerKind>(num: &FluentValue, _intls: &M) -> Option<String> {
     match num {
         FluentValue::Number(n) => Some(format!("CUSTOM({})", n.value).into()),
         _ => None,

--- a/fluent-bundle/examples/custom_type.rs
+++ b/fluent-bundle/examples/custom_type.rs
@@ -9,13 +9,13 @@
 // Lastly, we'll also create a new formatter which will be memoizable.
 //
 // The type and its options are modelled after ECMA402 Intl.DateTimeFormat.
-use std::sync::Mutex;
-
-use intl_memoizer::{IntlLangMemoizer, Memoizable};
+use intl_memoizer::Memoizable;
 use unic_langid::LanguageIdentifier;
 
-use fluent_bundle::types::{FluentType, FluentValue};
-use fluent_bundle::{FluentArgs, FluentBundle, FluentResource};
+use fluent_bundle::memoizer::MemoizerKind;
+use fluent_bundle::types::FluentType;
+use fluent_bundle::{concurrent, Memoizer};
+use fluent_bundle::{FluentArgs, FluentBundle, FluentResource, FluentValue};
 
 // First we're going to define what options our new type is going to accept.
 // For the sake of the example, we're only going to allow two options:
@@ -107,14 +107,15 @@ impl FluentType for DateTime {
     fn duplicate(&self) -> Box<dyn FluentType> {
         Box::new(DateTime::new(self.epoch, DateTimeOptions::default()))
     }
-    fn as_string(&self, intls: &Mutex<IntlLangMemoizer>) -> std::borrow::Cow<'static, str> {
-        let mut intls = intls
-            .lock()
-            .expect("Failed to get rw lock on intl memoizer.");
-        let dtf = intls
-            .try_get::<DateTimeFormatter>((self.options.clone(),))
-            .expect("Failed to retrieve a formatter.");
-        dtf.format(self.epoch).into()
+    fn as_string(&self, intls: &Memoizer) -> std::borrow::Cow<'static, str> {
+        intls
+            .with_try_get::<DateTimeFormatter, _, _>((self.options.clone(),), |dtf| {
+                dtf.format(self.epoch).into()
+            })
+            .expect("Failed to format a date.")
+    }
+    fn as_string_threadsafe(&self, _: &concurrent::Memoizer) -> std::borrow::Cow<'static, str> {
+        format!("2020-01-20 {}:00", self.epoch).into()
     }
 }
 

--- a/fluent-bundle/examples/custom_type.rs
+++ b/fluent-bundle/examples/custom_type.rs
@@ -12,7 +12,6 @@
 use intl_memoizer::Memoizable;
 use unic_langid::LanguageIdentifier;
 
-use fluent_bundle::memoizer::MemoizerKind;
 use fluent_bundle::types::FluentType;
 use fluent_bundle::{concurrent, Memoizer};
 use fluent_bundle::{FluentArgs, FluentBundle, FluentResource, FluentValue};

--- a/fluent-bundle/src/concurrent.rs
+++ b/fluent-bundle/src/concurrent.rs
@@ -1,0 +1,40 @@
+use std::sync::Mutex;
+
+use intl_memoizer::{IntlLangMemoizer, Memoizable};
+use unic_langid::LanguageIdentifier;
+
+use crate::bundle::FluentBundleBase;
+use crate::memoizer::MemoizerKind;
+use crate::types::FluentType;
+
+pub type Memoizer = Mutex<IntlLangMemoizer>;
+
+pub type FluentBundle<R> = FluentBundleBase<R, Memoizer>;
+
+impl MemoizerKind for Memoizer {
+    fn new(lang: LanguageIdentifier) -> Self
+    where
+        Self: Sized,
+    {
+        Mutex::new(IntlLangMemoizer::new(lang))
+    }
+
+    fn with_try_get<I, R, U>(&self, args: I::Args, cb: U) -> Result<R, ()>
+    where
+        Self: Sized,
+        I: Memoizable + 'static,
+        U: FnOnce(&I) -> R,
+    {
+        match self.lock() {
+            Ok(mut memoizer) => match memoizer.try_get(args) {
+                Ok(memoizable) => Ok(cb(&memoizable)),
+                Err(_) => Err(()),
+            },
+            Err(_) => Err(()),
+        }
+    }
+
+    fn stringify_value(&self, value: &dyn FluentType) -> std::borrow::Cow<'static, str> {
+        value.as_string_threadsafe(self)
+    }
+}

--- a/fluent-bundle/src/concurrent.rs
+++ b/fluent-bundle/src/concurrent.rs
@@ -1,13 +1,11 @@
-use std::sync::Mutex;
-
-use intl_memoizer::{IntlLangMemoizer, Memoizable};
+use intl_memoizer::{concurrent::IntlLangMemoizer, Memoizable};
 use unic_langid::LanguageIdentifier;
 
 use crate::bundle::FluentBundleBase;
 use crate::memoizer::MemoizerKind;
 use crate::types::FluentType;
 
-pub type Memoizer = Mutex<IntlLangMemoizer>;
+pub type Memoizer = IntlLangMemoizer;
 
 pub type FluentBundle<R> = FluentBundleBase<R, Memoizer>;
 
@@ -16,22 +14,17 @@ impl MemoizerKind for Memoizer {
     where
         Self: Sized,
     {
-        Mutex::new(IntlLangMemoizer::new(lang))
+        IntlLangMemoizer::new(lang)
     }
 
-    fn with_try_get<I, R, U>(&self, args: I::Args, cb: U) -> Result<R, ()>
+    fn with_try_get_threadsafe<I, R, U>(&self, args: I::Args, cb: U) -> Result<R, I::Error>
     where
         Self: Sized,
-        I: Memoizable + 'static,
+        I: Memoizable + Send + Sync + 'static,
+        I::Args: Send + Sync + 'static,
         U: FnOnce(&I) -> R,
     {
-        match self.lock() {
-            Ok(mut memoizer) => match memoizer.try_get(args) {
-                Ok(memoizable) => Ok(cb(&memoizable)),
-                Err(_) => Err(()),
-            },
-            Err(_) => Err(()),
-        }
+        self.with_try_get(args, cb)
     }
 
     fn stringify_value(&self, value: &dyn FluentType) -> std::borrow::Cow<'static, str> {

--- a/fluent-bundle/src/entry.rs
+++ b/fluent-bundle/src/entry.rs
@@ -4,7 +4,7 @@ use std::borrow::Borrow;
 
 use fluent_syntax::ast;
 
-use crate::bundle::{FluentArgs, FluentBundle};
+use crate::bundle::{FluentArgs, FluentBundleBase};
 use crate::resource::FluentResource;
 use crate::types::FluentValue;
 
@@ -23,7 +23,7 @@ pub trait GetEntry {
     fn get_entry_function(&self, id: &str) -> Option<&FluentFunction>;
 }
 
-impl<'bundle, R: Borrow<FluentResource>> GetEntry for FluentBundle<R> {
+impl<'bundle, R: Borrow<FluentResource>, M> GetEntry for FluentBundleBase<R, M> {
     fn get_entry_message(&self, id: &str) -> Option<&ast::Message> {
         self.entries.get(id).and_then(|entry| match *entry {
             Entry::Message(pos) => {

--- a/fluent-bundle/src/memoizer.rs
+++ b/fluent-bundle/src/memoizer.rs
@@ -1,0 +1,17 @@
+use crate::types::FluentType;
+use intl_memoizer::Memoizable;
+use unic_langid::LanguageIdentifier;
+
+pub trait MemoizerKind: 'static {
+    fn new(lang: LanguageIdentifier) -> Self
+    where
+        Self: Sized;
+
+    fn with_try_get<I, R, U>(&self, args: I::Args, cb: U) -> Result<R, ()>
+    where
+        Self: Sized,
+        I: Memoizable + 'static,
+        U: FnOnce(&I) -> R;
+
+    fn stringify_value(&self, value: &dyn FluentType) -> std::borrow::Cow<'static, str>;
+}

--- a/fluent-bundle/src/memoizer.rs
+++ b/fluent-bundle/src/memoizer.rs
@@ -7,10 +7,11 @@ pub trait MemoizerKind: 'static {
     where
         Self: Sized;
 
-    fn with_try_get<I, R, U>(&self, args: I::Args, cb: U) -> Result<R, ()>
+    fn with_try_get_threadsafe<I, R, U>(&self, args: I::Args, cb: U) -> Result<R, I::Error>
     where
         Self: Sized,
-        I: Memoizable + 'static,
+        I: Memoizable + Send + Sync + 'static,
+        I::Args: Send + Sync + 'static,
         U: FnOnce(&I) -> R;
 
     fn stringify_value(&self, value: &dyn FluentType) -> std::borrow::Cow<'static, str>;

--- a/fluent-bundle/src/types/mod.rs
+++ b/fluent-bundle/src/types/mod.rs
@@ -9,14 +9,15 @@ use std::borrow::{Borrow, Cow};
 use std::default::Default;
 use std::fmt;
 use std::str::FromStr;
-use std::sync::Mutex;
 
 use fluent_syntax::ast;
-use intl_memoizer::IntlLangMemoizer;
 use intl_pluralrules::{PluralCategory, PluralRuleType};
 
+use crate::concurrent;
+use crate::memoizer::MemoizerKind;
 use crate::resolve::Scope;
 use crate::resource::FluentResource;
+use crate::Memoizer;
 
 #[derive(Debug, PartialEq, Clone)]
 pub enum DisplayableNodeType<'source> {
@@ -109,7 +110,8 @@ impl<'source> From<&ast::InlineExpression<'source>> for DisplayableNode<'source>
 
 pub trait FluentType: fmt::Debug + AnyEq + 'static {
     fn duplicate(&self) -> Box<dyn FluentType>;
-    fn as_string(&self, intls: &Mutex<IntlLangMemoizer>) -> Cow<'static, str>;
+    fn as_string(&self, intls: &Memoizer) -> Cow<'static, str>;
+    fn as_string_threadsafe(&self, intls: &concurrent::Memoizer) -> Cow<'static, str>;
 }
 
 impl PartialEq for dyn FluentType {
@@ -156,7 +158,6 @@ pub enum FluentValue<'source> {
     Error(DisplayableNode<'source>),
     None,
 }
-
 impl<'s> PartialEq for FluentValue<'s> {
     fn eq(&self, other: &Self) -> bool {
         match (self, other) {
@@ -193,10 +194,10 @@ impl<'source> FluentValue<'source> {
         }
     }
 
-    pub fn matches<R: Borrow<FluentResource>>(
+    pub fn matches<R: Borrow<FluentResource>, M: MemoizerKind>(
         &self,
         other: &FluentValue,
-        scope: &Scope<R>,
+        scope: &Scope<R, M>,
     ) -> bool {
         match (self, other) {
             (&FluentValue::String(ref a), &FluentValue::String(ref b)) => a == b,
@@ -211,21 +212,22 @@ impl<'source> FluentValue<'source> {
                     "other" => PluralCategory::OTHER,
                     _ => return false,
                 };
-                let mut intls = scope
+                scope
                     .bundle
                     .intls
-                    .lock()
-                    .expect("Failed to get rw lock on intl memoizer.");
-                let pr = intls
-                    .try_get::<PluralRules>((PluralRuleType::CARDINAL,))
-                    .expect("Failed to retrieve plural rules");
-                pr.0.select(b) == Ok(cat)
+                    .with_try_get::<PluralRules, _, _>((PluralRuleType::CARDINAL,), |pr| {
+                        pr.0.select(b) == Ok(cat)
+                    })
+                    .unwrap()
             }
             _ => false,
         }
     }
 
-    pub fn as_string<R: Borrow<FluentResource>>(&self, scope: &Scope<R>) -> Cow<'source, str> {
+    pub fn as_string<R: Borrow<FluentResource>, M: MemoizerKind>(
+        &self,
+        scope: &Scope<R, M>,
+    ) -> Cow<'source, str> {
         if let Some(formatter) = &scope.bundle.formatter {
             if let Some(val) = formatter(self, &scope.bundle.intls) {
                 return val.into();
@@ -235,7 +237,7 @@ impl<'source> FluentValue<'source> {
             FluentValue::String(s) => s.clone(),
             FluentValue::Number(n) => n.as_string(),
             FluentValue::Error(d) => format!("{{{}}}", d.to_string()).into(),
-            FluentValue::Custom(s) => s.as_string(&scope.bundle.intls),
+            FluentValue::Custom(s) => scope.bundle.intls.stringify_value(&**s),
             FluentValue::None => "???".into(),
         }
     }

--- a/fluent-bundle/src/types/mod.rs
+++ b/fluent-bundle/src/types/mod.rs
@@ -215,7 +215,7 @@ impl<'source> FluentValue<'source> {
                 scope
                     .bundle
                     .intls
-                    .with_try_get::<PluralRules, _, _>((PluralRuleType::CARDINAL,), |pr| {
+                    .with_try_get_threadsafe::<PluralRules, _, _>((PluralRuleType::CARDINAL,), |pr| {
                         pr.0.select(b) == Ok(cat)
                     })
                     .unwrap()

--- a/fluent-bundle/src/types/number.rs
+++ b/fluent-bundle/src/types/number.rs
@@ -237,7 +237,7 @@ from_num!(f32 f64);
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use crate::types::FluentValue;
 
     #[test]
     fn value_from_copy_ref() {

--- a/fluent-bundle/tests/custom_types.rs
+++ b/fluent-bundle/tests/custom_types.rs
@@ -1,10 +1,10 @@
+use fluent_bundle::memoizer::MemoizerKind;
 use fluent_bundle::types::FluentType;
 use fluent_bundle::FluentArgs;
 use fluent_bundle::FluentBundle;
 use fluent_bundle::FluentResource;
 use fluent_bundle::FluentValue;
-use intl_memoizer::IntlLangMemoizer;
-use std::sync::Mutex;
+use fluent_bundle::{concurrent, Memoizer};
 use unic_langid::langid;
 
 #[test]
@@ -24,7 +24,10 @@ fn fluent_custom_type() {
         fn duplicate(&self) -> Box<dyn FluentType> {
             Box::new(DateTime { epoch: self.epoch })
         }
-        fn as_string(&self, _intls: &Mutex<IntlLangMemoizer>) -> std::borrow::Cow<'static, str> {
+        fn as_string(&self, _: &Memoizer) -> std::borrow::Cow<'static, str> {
+            format!("{}", self.epoch).into()
+        }
+        fn as_string_threadsafe(&self, _: &concurrent::Memoizer) -> std::borrow::Cow<'static, str> {
             format!("{}", self.epoch).into()
         }
     }
@@ -115,7 +118,13 @@ fn fluent_date_time_builtin() {
         fn duplicate(&self) -> Box<dyn FluentType> {
             Box::new(DateTime::new(self.epoch, DateTimeOptions::default()))
         }
-        fn as_string(&self, _intls: &Mutex<IntlLangMemoizer>) -> std::borrow::Cow<'static, str> {
+        fn as_string(&self, _intls: &Memoizer) -> std::borrow::Cow<'static, str> {
+            format!("2020-01-20 {}:00", self.epoch).into()
+        }
+        fn as_string_threadsafe(
+            &self,
+            _intls: &concurrent::Memoizer,
+        ) -> std::borrow::Cow<'static, str> {
             format!("2020-01-20 {}:00", self.epoch).into()
         }
     }
@@ -171,7 +180,7 @@ key-ref = Hello { DATETIME($date, dateStyle: "full") } World
 
 #[test]
 fn fluent_custom_number_format() {
-    fn custom_formatter(num: &FluentValue, _intls: &Mutex<IntlLangMemoizer>) -> Option<String> {
+    fn custom_formatter<M: MemoizerKind>(num: &FluentValue, _intls: &M) -> Option<String> {
         match num {
             FluentValue::Number(_) => Some("CUSTOM".into()),
             _ => None,

--- a/intl-memoizer/examples/numberformat.rs
+++ b/intl-memoizer/examples/numberformat.rs
@@ -40,48 +40,39 @@ fn main() {
     {
         // Create an en-US memoizer
         let lang_memoizer = memoizer.get_for_lang(lang.clone());
-        {
-            let mut lang_memoizer2 = lang_memoizer.borrow_mut();
 
-            let options = NumberFormatOptions {
-                minimum_fraction_digits: 3,
-                maximum_fraction_digits: 5,
-            };
-            let nf = lang_memoizer2.try_get::<NumberFormat>((options,)).unwrap();
 
-            assert_eq!(&nf.format(2), "en-US: 2, MFD: 3");
-        }
+        let options = NumberFormatOptions {
+            minimum_fraction_digits: 3,
+            maximum_fraction_digits: 5,
+        };
+        let result = lang_memoizer.with_try_get::<NumberFormat, _, _>((options,), |nf| nf.format(2)).unwrap();
+
+        assert_eq!(&result, "en-US: 2, MFD: 3");
+
 
         // Reuse the same en-US memoizer
-        let lang_memoizer3 = memoizer.get_for_lang(lang.clone());
-        {
-            let mut lang_memoizer4 = lang_memoizer3.borrow_mut();
+        let lang_memoizer = memoizer.get_for_lang(lang.clone());
 
-            let options2 = NumberFormatOptions {
-                minimum_fraction_digits: 3,
-                maximum_fraction_digits: 5,
-            };
-            let nf2 = lang_memoizer4.try_get::<NumberFormat>((options2,)).unwrap();
+        let options = NumberFormatOptions {
+            minimum_fraction_digits: 3,
+            maximum_fraction_digits: 5,
+        };
+        let result = lang_memoizer.with_try_get::<NumberFormat, _, _>((options,), |nf| nf.format(2)).unwrap();
 
-            assert_eq!(&nf2.format(2), "en-US: 2, MFD: 3");
-        }
+        assert_eq!(&result, "en-US: 2, MFD: 3");
 
-        // Memoizer gets dropped
     }
 
     {
         // Here, we will construct a new lang memoizer
         let lang_memoizer = memoizer.get_for_lang(lang.clone());
-        {
-            let mut lang_memoizer2 = lang_memoizer.borrow_mut();
+        let options = NumberFormatOptions {
+            minimum_fraction_digits: 3,
+            maximum_fraction_digits: 5,
+        };
+        let result = lang_memoizer.with_try_get::<NumberFormat, _, _>((options,), |nf| nf.format(2)).unwrap();
 
-            let options = NumberFormatOptions {
-                minimum_fraction_digits: 3,
-                maximum_fraction_digits: 5,
-            };
-            let nf = lang_memoizer2.try_get::<NumberFormat>((options,)).unwrap();
-
-            assert_eq!(&nf.format(2), "en-US: 2, MFD: 3");
-        }
+        assert_eq!(&result, "en-US: 2, MFD: 3");
     }
 }

--- a/intl-memoizer/examples/pluralrules.rs
+++ b/intl-memoizer/examples/pluralrules.rs
@@ -23,11 +23,10 @@ fn main() {
 
     let lang: LanguageIdentifier = "en".parse().unwrap();
     let lang_memoizer = memoizer.get_for_lang(lang.clone());
-    let mut lang_memoizer_borrow = lang_memoizer.borrow_mut();
 
-    let pr = lang_memoizer_borrow
-        .try_get::<PluralRules>((PluralRuleType::CARDINAL,))
+    let result = lang_memoizer
+        .with_try_get::<PluralRules, _, _>((PluralRuleType::CARDINAL,), |pr| pr.0.select(5))
         .unwrap();
 
-    assert_eq!(pr.0.select(5), Ok(PluralCategory::OTHER));
+    assert_eq!(result, Ok(PluralCategory::OTHER));
 }

--- a/intl-memoizer/src/concurrent.rs
+++ b/intl-memoizer/src/concurrent.rs
@@ -1,0 +1,38 @@
+use super::*;
+
+#[derive(Debug)]
+pub struct IntlLangMemoizer {
+    lang: LanguageIdentifier,
+    map: type_map::concurrent::TypeMap,
+}
+
+impl IntlLangMemoizer {
+    pub fn new(lang: LanguageIdentifier) -> Self {
+        Self {
+            lang,
+            map: type_map::concurrent::TypeMap::new(),
+        }
+    }
+
+    pub fn try_get<T: Memoizable + Sync + Send + 'static>(
+        &mut self,
+        args: T::Args,
+    ) -> Result<&T, T::Error>
+    where
+        T::Args: Eq + Sync + Send,
+    {
+        let cache = self
+            .map
+            .entry::<HashMap<T::Args, T>>()
+            .or_insert_with(HashMap::new);
+
+        let e = match cache.entry(args.clone()) {
+            Entry::Occupied(entry) => entry.into_mut(),
+            Entry::Vacant(entry) => {
+                let val = T::construct(self.lang.clone(), args)?;
+                entry.insert(val)
+            }
+        };
+        Ok(e)
+    }
+}

--- a/intl-memoizer/src/lib.rs
+++ b/intl-memoizer/src/lib.rs
@@ -3,8 +3,9 @@ use std::collections::hash_map::Entry;
 use std::collections::HashMap;
 use std::hash::Hash;
 use std::rc::{Rc, Weak};
-use type_map::concurrent::TypeMap;
 use unic_langid::LanguageIdentifier;
+
+pub mod concurrent;
 
 pub trait Memoizable {
     type Args: 'static + Eq + Hash + Clone;
@@ -14,22 +15,23 @@ pub trait Memoizable {
         Self: std::marker::Sized;
 }
 
+#[derive(Debug)]
 pub struct IntlLangMemoizer {
     lang: LanguageIdentifier,
-    map: TypeMap,
+    map: type_map::TypeMap,
 }
 
 impl IntlLangMemoizer {
     pub fn new(lang: LanguageIdentifier) -> Self {
         Self {
             lang,
-            map: TypeMap::new(),
+            map: type_map::TypeMap::new(),
         }
     }
 
-    pub fn try_get<T: Memoizable + Sync + Send + 'static>(&mut self, args: T::Args) -> Result<&T, T::Error>
+    pub fn try_get<T: Memoizable + 'static>(&mut self, args: T::Args) -> Result<&T, T::Error>
     where
-        T::Args: Eq + Sync + Send,
+        T::Args: Eq,
     {
         let cache = self
             .map

--- a/intl-memoizer/src/lib.rs
+++ b/intl-memoizer/src/lib.rs
@@ -18,34 +18,38 @@ pub trait Memoizable {
 #[derive(Debug)]
 pub struct IntlLangMemoizer {
     lang: LanguageIdentifier,
-    map: type_map::TypeMap,
+    map: RefCell<type_map::TypeMap>,
 }
 
 impl IntlLangMemoizer {
     pub fn new(lang: LanguageIdentifier) -> Self {
         Self {
             lang,
-            map: type_map::TypeMap::new(),
+            map: RefCell::new(type_map::TypeMap::new()),
         }
     }
 
-    pub fn try_get<T: Memoizable + 'static>(&mut self, args: T::Args) -> Result<&T, T::Error>
+    pub fn with_try_get<I, R, U>(&self, args: I::Args, cb: U) -> Result<R, I::Error>
     where
-        T::Args: Eq,
+        Self: Sized,
+        I: Memoizable + 'static,
+        U: FnOnce(&I) -> R,
     {
-        let cache = self
-            .map
-            .entry::<HashMap<T::Args, T>>()
+        let mut map = self.map.try_borrow_mut().expect("Cannot use memoizer reentrantly");
+        let cache = map
+            .entry::<HashMap<I::Args, I>>()
             .or_insert_with(HashMap::new);
 
         let e = match cache.entry(args.clone()) {
             Entry::Occupied(entry) => entry.into_mut(),
             Entry::Vacant(entry) => {
-                let val = T::construct(self.lang.clone(), args)?;
+                let val = I::construct(self.lang.clone(), args)?;
                 entry.insert(val)
             }
         };
-        Ok(e)
+
+        let r = cb(&e);
+        Ok(r)
     }
 }
 


### PR DESCRIPTION
This does get rid of the very convenient `try_get` function sadly, `with_try_get` is more annoying to use. I don't think many people will be using this though so it's probably not a big deal.

This makes it very easy to switch over to `parking_lot::RWLock` however, since the mutex isn't exposed at all anymore.